### PR TITLE
LFLT-336 CBFS unnecessarily wraps categories in body node

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>cbfs</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.4.1-dev</version>
+        <version>1.4.2-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/src/main/java/hu/psprog/leaflet/cbfs/service/snapshot/impl/CategoryListSnapshotRetrievalService.java
+++ b/core/src/main/java/hu/psprog/leaflet/cbfs/service/snapshot/impl/CategoryListSnapshotRetrievalService.java
@@ -25,7 +25,6 @@ public class CategoryListSnapshotRetrievalService implements SnapshotRetrievalSe
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CategoryListSnapshotRetrievalService.class);
 
-    private static final String BODY = "body";
     private static final String CATEGORIES = "categories";
 
     private CategoryDAO categoryDAO;
@@ -40,7 +39,7 @@ public class CategoryListSnapshotRetrievalService implements SnapshotRetrievalSe
     @Override
     public String retrieve(Void key) {
 
-        Map<String, Map<String, List<Category>>> result = buildWrapper(categoryDAO.getCategories());
+        Map<String, List<Category>> result = buildWrapper(categoryDAO.getCategories());
         String snapshot = StringUtils.EMPTY;
         try {
             snapshot = objectMapper.writeValueAsString(result);
@@ -51,14 +50,11 @@ public class CategoryListSnapshotRetrievalService implements SnapshotRetrievalSe
         return snapshot;
     }
 
-    private Map<String, Map<String, List<Category>>> buildWrapper(List<Category> categoryList) {
+    private Map<String, List<Category>> buildWrapper(List<Category> categoryList) {
 
         Map<String, List<Category>> categoryMap = new HashMap<>();
         categoryMap.put(CATEGORIES, categoryList);
 
-        Map<String, Map<String, List<Category>>> wrapper = new HashMap<>();
-        wrapper.put(BODY, categoryMap);
-
-        return wrapper;
+        return categoryMap;
     }
 }

--- a/core/src/test/java/hu/psprog/leaflet/cbfs/service/snapshot/impl/CategoryListSnapshotRetrievalServiceTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/cbfs/service/snapshot/impl/CategoryListSnapshotRetrievalServiceTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.doThrow;
 @RunWith(MockitoJUnitRunner.class)
 public class CategoryListSnapshotRetrievalServiceTest {
 
-    private static final String EXPECTED_JSON_VALUE = "{\"body\":{\"categories\":[{\"id\":1,\"title\":\"category-1\"},{\"id\":2,\"title\":\"category-2\"}]}}";
+    private static final String EXPECTED_JSON_VALUE = "{\"categories\":[{\"id\":1,\"title\":\"category-1\"},{\"id\":2,\"title\":\"category-2\"}]}";
 
     @Mock
     private CategoryDAO categoryDAO;

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>hu.psprog.leaflet</groupId>
     <artifactId>cbfs</artifactId>
     <packaging>pom</packaging>
-    <version>1.4.1-dev</version>
+    <version>1.4.2-dev</version>
     <name>Leaflet Content Backup Failover System</name>
 
     <modules>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>cbfs</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.4.1-dev</version>
+        <version>1.4.2-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
 - Removed body node from public categories snapshot response
 - Aligned test