### PR TITLE
LFLT-363 Add publish date for articles

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>cbfs</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.4.2-dev</version>
+        <version>1.4.3-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -56,6 +56,10 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>hu.psprog.leaflet</groupId>
     <artifactId>cbfs</artifactId>
     <packaging>pom</packaging>
-    <version>1.4.2-dev</version>
+    <version>1.4.3-dev</version>
     <name>Leaflet Content Backup Failover System</name>
 
     <modules>
@@ -23,8 +23,8 @@
         <!-- leaflet internal dependency versions -->
         <leaflet-rcp.version>1.4.0</leaflet-rcp.version>
         <leaflet.tlp-appender.version>1.1.0</leaflet.tlp-appender.version>
-        <leaflet.bridge.version>3.2.1</leaflet.bridge.version>
-        <leaflet.rest-api.version>1.6.1</leaflet.rest-api.version>
+        <leaflet.bridge.version>3.2.3</leaflet.bridge.version>
+        <leaflet.rest-api.version>1.6.6</leaflet.rest-api.version>
 
         <!-- dependency versions -->
         <spark-java.version>2.8.0</spark-java.version>
@@ -128,6 +128,11 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-xml</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>cbfs</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.4.2-dev</version>
+        <version>1.4.3-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
 - Updated REST API version to v1.6.6
 - Updated Bridge version to v3.2.3
 - Added missing Jackson Data Format XML module (caused by API update)