### PR TITLE
LFLT-480 Update dependencies of Leaflet stack components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
   # Leaflet Content Backup Failover System - Build and test application
   build:
     docker:
-      - image: cimg/openjdk:11.0.12
+      - image: cimg/openjdk:11.0
     steps:
       - checkout
       - run:
@@ -69,7 +69,7 @@ jobs:
           command: echo 'export PROJECT_VERSION=`mvn help:evaluate -Dexpression=project.version -q -DforceStdout --non-recursive -s .circleci/settings.xml`' >> $BASH_ENV
           name: Extract project version
       - setup_remote_docker:
-          version: 19.03.12
+          version: 20.10.14
       - run:
           command: mvn clean deploy -s .circleci/settings.xml
           name: Build
@@ -94,7 +94,7 @@ jobs:
   # Leaflet Content Backup Failover System - Deploy to production
   deploy:
     docker:
-      - image: cimg/openjdk:11.0.12
+      - image: cimg/openjdk:11.0
     steps:
       - attach_workspace:
           at: << pipeline.parameters.workspace_dir >>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>cbfs</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.5.0-dev</version>
+        <version>1.6.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/src/main/resources/failover_init.sql
+++ b/core/src/main/resources/failover_init.sql
@@ -1,13 +1,13 @@
 create table cbfs_status_tracking (
-  id int(11) auto_increment not null primary key,
+  id bigint auto_increment not null primary key,
   created_at datetime not null,
   status varchar(20) not null,
   parameter varchar(20) default null
 );
 
 create table cbfs_entry_page (
-  page_number int(11) not null,
-  category_id int(11) default null,
+  page_number bigint not null,
+  category_id bigint default null,
   link_list text,
   content text
 );
@@ -23,6 +23,6 @@ create table cbfs_document (
 );
 
 create table cbfs_category (
-  id int(11) not null primary key,
+  id bigint not null primary key,
   title varchar(255)
 )

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
 
     <artifactId>cbfs</artifactId>
     <packaging>pom</packaging>
-    <version>1.5.0-dev</version>
+    <version>1.6.0-dev</version>
     <name>Leaflet Content Backup Failover System</name>
 
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>1.0-r2110.1</version>
+        <version>2.0-r2208.1</version>
     </parent>
 
     <modules>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>cbfs</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.5.0-dev</version>
+        <version>1.6.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
 - Changed CircleCI build image version
 - Changed CircleCI Docker build environment version
 - Updated Leaflet Stack Base BOM version to 2.0-r2208.1
 - Fixed an H2 incompatibility issue
 - Bumped version to 1.6.0-dev